### PR TITLE
Add possibility to change orientation and to add a manual pagebreak

### DIFF
--- a/ODT/ODTDefaultStyles.php
+++ b/ODT/ODTDefaultStyles.php
@@ -153,6 +153,14 @@ class ODTDefaultStyles extends ODTStyleSet
                 <style:header-style/>
                 <style:footer-style/>
             </style:page-layout>',
+        "pm2"=>'
+            <style:page-layout style:name="pm2">
+                <style:page-layout-properties fo:page-width="'.$page->getHeight().'cm" fo:page-height="'.$page->getWidth().'cm" style:num-format="1" style:print-orientation="landscape" fo:margin-top="'.$page->getMarginTop().'cm" fo:margin-bottom="'.$page->getMarginBottom().'cm" fo:margin-left="'.$page->getMarginLeft().'cm" fo:margin-right="'.$page->getMarginRight().'cm" style:writing-mode="lr-tb" style:footnote-max-height="0cm">
+                    <style:footnote-sep style:width="0.018cm" style:distance-before-sep="0.1cm" style:distance-after-sep="0.1cm" style:adjustment="left" style:rel-width="25%" style:color="#000000"/>
+                </style:page-layout-properties>
+                <style:header-style/>
+                <style:footer-style/>
+            </style:page-layout>',
         "sub"=>'
             <style:style style:name="sub" style:family="text">
                 <style:text-properties style:text-position="-33% 80%"/>

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -772,6 +772,35 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         }
     }
 
+    protected function createLandscapeStyle() {
+        if ( empty ($this->autostyles['landscape']) ) {
+            $this->autostyles['landscape'] = '<style:style style:name="landscape" style:family="paragraph" style:master-page-name="Landscape" parent-style-name="Standard"><style:paragraph-properties style:page-number="auto"/></style:style>';
+        }
+    }
+
+    protected function createPortraitStyle() {
+        if ( empty ($this->autostyles['portrait']) ) {
+            $this->autostyles['portrait'] = '<style:style style:name="portrait" style:family="paragraph" style:master-page-name="Standard" parent-style-name="Standard"><style:paragraph-properties style:page-number="auto"/></style:style>';
+        }
+    }
+
+    function set_orientation($orientation = 'portrait')
+    {
+        switch($orientation)
+        {
+            case 'portrait':
+                $this->createPortraitStyle();
+                $this->p_close();
+                $this->doc .= '<text:p text:style-name="portrait"/>';
+            break;
+            case 'landscape':
+                $this->createLandscapeStyle();
+                $this->p_close();
+                $this->doc .= '<text:p text:style-name="landscape"/>';
+            break;
+        }
+    }
+
     function pagebreak() {
         $this->createPagebreakStyle();
         $this->p_close();

--- a/styles.xml
+++ b/styles.xml
@@ -174,6 +174,7 @@
 
     <office:master-styles>
         <style:master-page style:name="Standard" style:page-layout-name="pm1"/>
+        <style:master-page style:name="Landscape" style:page-layout-name="pm2"/>
     </office:master-styles>
 </office:document-styles>
 

--- a/syntax.php
+++ b/syntax.php
@@ -119,6 +119,16 @@ class syntax_plugin_odt extends DokuWiki_Syntax_Plugin {
                      $renderer->meta['relation']['odt']['toc'] = $info_value;
                  }
             }
+            if($info_type == "orientation") { // Change page's orientation here
+                if($format == 'odt') {
+                    $renderer->set_orientation($info_value);
+                }
+            }
+            if($info_type == "pagebreak") {
+                if($format == 'odt') {
+                    $renderer->pagebreak();
+                }
+            }
         }
         return false;
     }


### PR DESCRIPTION
This adds syntax and styles to change the orientation to landscape and back to portrait anywhere within the document. A manual page break is also possible. Use {{odt>orientation:landscape}} to change to landscape, {{odt>orientation:portrait}} to change back to portrait and {{odt>pagebreak}} to add a manual break. 
Due to the syntax plugin being PType 'normal', you need to open a new paragraph in wiki text, so an empty line following the {{odt>}} call is required.