### PR TITLE
Add possibility to temporarily disable creating links

### DIFF
--- a/renderer/book.php
+++ b/renderer/book.php
@@ -65,6 +65,8 @@ class renderer_plugin_odt_book extends renderer_plugin_odt_page {
      */
     public function document_end() {
          //ODT file creation is performed by finalize_ODTfile()
+         // Switch links back on in case they were disabled at some point
+         $this->enable_links();
     }
 
     /**

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -65,6 +65,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
     protected $quote_depth = 0;
     protected $quote_pos = 0;
     protected $div_z_index = 0;
+    protected $disable_links = false;
     /** @var pageFormat */
     protected $page = null;
     /** @var refIDCount */
@@ -308,6 +309,19 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         $this->doc = $this->docHandler->get();
     }
 
+    /**
+     * Simple setter to enable creating links
+     */
+    function enable_links() {
+        $this->disable_links = false;
+    }
+
+    /**
+     * Simple setter to disable creating links
+     */
+    function disable_links() {
+        $this->disable_links = true;
+    }
 
     /**
      * This function does not really render the TOC but inserts a placeholder.
@@ -1608,7 +1622,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         $url = $this->_xmlEntities($url);
         if(is_array($name)){
             // Images
-            if($url) $this->doc .= '<draw:a xlink:type="simple" xlink:href="'.$url.'">';
+            if($url && !$this->disable_links) $this->doc .= '<draw:a xlink:type="simple" xlink:href="'.$url.'">';
 
             if($name['type'] == 'internalmedia'){
                 $this->internalmedia($name['src'],
@@ -1620,12 +1634,12 @@ class renderer_plugin_odt_page extends Doku_Renderer {
                                      $name['linking']);
             }
 
-            if($url) $this->doc .= '</draw:a>';
+            if($url && !$this->disable_links) $this->doc .= '</draw:a>';
         }else{
             // Text
-            if($url) $this->doc .= '<text:a xlink:type="simple" xlink:href="'.$url.'">';
+            if($url && !$this->disable_links) $this->doc .= '<text:a xlink:type="simple" xlink:href="'.$url.'">';
             $this->doc .= $name; // we get the name already XML encoded
-            if($url) $this->doc .= '</text:a>';
+            if($url && !$this->disable_links) $this->doc .= '</text:a>';
         }
     }
 

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -287,6 +287,9 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         //$this->doc .= 'Path: '.$conf['mediadir'].'/'.$this->getConf("tpl_dir")."/".$this->template;
         //$this->p_close();
 
+        // Switch links back on
+        $this->enable_links();
+
         // Insert TOC (if required)
         $this->insert_TOC();
 

--- a/syntax.php
+++ b/syntax.php
@@ -98,26 +98,39 @@ class syntax_plugin_odt extends DokuWiki_Syntax_Plugin {
         } else { // Extended info
 
             list($info_type, $info_value) = $data;
-            if($info_type == "template") { // Template-based export
-                 if($format == 'odt') {
-                     /** @var renderer_plugin_odt_page $renderer */
-                     $renderer->template = $info_value;
+            switch($info_type)
+            {
+                case 'template': // Template-based export
+                    if($format == 'odt') {
+                        /** @var renderer_plugin_odt_page $renderer */
+                        $renderer->template = $info_value;
 
-                 } elseif($format == 'metadata') {
-                     /** @var Doku_Renderer_metadata $renderer */
-                     $renderer->meta['relation']['odt']['template'] = $info_value;
-                 }
-            }
-            if($info_type == "toc") { // Insert TOC in exported ODT file
-                 if($format == 'odt') {
-                     /** @var renderer_plugin_odt_page $renderer */
-                     $renderer->toc_settings = $info_value;
-                     $renderer->render_TOC();
+                    } elseif($format == 'metadata') {
+                        /** @var Doku_Renderer_metadata $renderer */
+                        $renderer->meta['relation']['odt']['template'] = $info_value;
+                    }
+                break;
+                case 'toc': // Insert TOC in exported ODT file
+                    if($format == 'odt') {
+                        /** @var renderer_plugin_odt_page $renderer */
+                        $renderer->toc_settings = $info_value;
+                        $renderer->render_TOC();
 
-                 } elseif($format == 'metadata') {
-                     /** @var Doku_Renderer_metadata $renderer */
-                     $renderer->meta['relation']['odt']['toc'] = $info_value;
-                 }
+                    } elseif($format == 'metadata') {
+                        /** @var Doku_Renderer_metadata $renderer */
+                        $renderer->meta['relation']['odt']['toc'] = $info_value;
+                    }
+                break;
+                case 'disablelinks': // Disable creating links and only show the text instead
+                    if($format == 'odt') {
+                        $renderer->disable_links();
+                    }
+                break;
+                case 'enablelinks': // Re-enable creating links
+                    if($format == 'odt') {
+                        $renderer->enable_links();
+                    }
+                break;
             }
         }
         return false;


### PR DESCRIPTION
Sometimes, we need to disable creating actual links in the ODT file, e.g. for tables generated by the data plugin. 

With this PR, you can simply do {{odt>disablelinks}} in the wiki file and most (all?) links to pages and e-mail addresses should be rendered as text instead. Afterwards, you can call {{odt>enablelinks}} to re-enable link generation.