### PR TITLE
Made helper/config.php PHP 5.4 compatible

### DIFF
--- a/helper/config.php
+++ b/helper/config.php
@@ -570,7 +570,7 @@ class helper_plugin_odt_config extends DokuWiki_Plugin {
 
         $template = $this->getParam ('template');
         $odt_template = $this->getParam ('odt_template');
-        if (!empty($this->getParam ('template')) && empty($this->getParam ('odt_template'))) {
+        if (!empty($template) && empty($odt_template)) {
             $this->setParam ('odt_template', $this->getParam ('template'));
         }
 


### PR DESCRIPTION
There is one line in helper/config.php that fails for systems using PHP v5.4. You can't call a function within an empty() call in PHP <= 5.4. The two functions are called right before anyway, for $template and $odt_template, so was also redundant. 