### PR TITLE
Re-factoring of state variables

### DIFF
--- a/ODT/ODTState.php
+++ b/ODT/ODTState.php
@@ -1,0 +1,290 @@
+<?php
+
+/**
+ * ODTState: class for maintaining the ODT state.
+ *
+ * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author  LarsDW223
+ */
+class ODTStateEntry
+{
+    protected $element = NULL;
+    protected $clazz = NULL;
+    protected $style_name = NULL;
+    protected $in_list = false;
+    protected $in_list_item = false;
+    protected $list_interrupted = false;
+    protected $list_interrupt_now = false;
+    protected $in_paragraph = false;
+    protected $in_frame = false;
+    protected $in_header = false;
+    protected $table_column_styles = array ();
+    protected $table_style = NULL;
+    protected $autocols = false;
+    protected $maxcols = 0;
+    protected $column = 0;
+    protected $content = NULL;
+    protected $cols = NULL;
+    protected $temp_style_name = NULL;
+    // Temp pointer for various use! Can point to different things!
+    protected $temp = NULL;
+
+    function __clone() {
+        $this->element = NULL;
+        $this->clazz = NULL;
+        $this->temp_style = NULL;
+
+        $this->table_column_styles = array ();
+        $this->table_style = NULL;
+        $this->autocols = false;
+        $this->maxcols = 0;
+        $this->column = 0;
+        $this->content = NULL;
+        $this->cols = NULL;
+
+        $this->list_interrupted = false;
+        $this->list_interrupt_now = false;
+    }
+
+    public function setElement($value) {
+        $this->element = $value;
+    }
+    public function getElement() {
+        return $this->element;
+    }
+
+    public function setClass($value) {
+        $this->clazz = $value;
+    }
+    public function getClass() {
+        return $this->clazz;
+    }
+
+    public function setStyleName($value) {
+        $this->style_name = $value;
+    }
+    public function getStyleName() {
+        return $this->style_name;
+    }
+
+    public function setTempStyleName($value) {
+        $this->temp_style_name = $value;
+    }
+    public function getTempStyleName() {
+        return $this->temp_style_name;
+    }
+
+    public function setInList($value) {
+        $this->in_list = $value;
+    }
+    public function getInList() {
+        return $this->in_list;
+    }
+
+    public function setListInterrupted($value) {
+        $this->list_interrupted = $value;
+    }
+    public function getListInterrupted() {
+        return $this->list_interrupted;
+    }
+
+    public function setListInterruptNow($value) {
+        $this->list_interrupt_now = $value;
+    }
+    public function getListInterruptNow() {
+        return $this->list_interrupt_now;
+    }
+
+    public function setInListItem($value) {
+        $this->in_list_item = $value;
+    }
+    public function getInListItem() {
+        return $this->in_list_item;
+    }
+
+    public function setInParagraph($value) {
+        $this->in_paragraph = $value;
+    }
+    public function getInParagraph() {
+        return $this->in_paragraph;
+    }
+
+    public function setInHeader($value) {
+        $this->in_header = $value;
+    }
+    public function getInHeader() {
+        return $this->in_header;
+    }
+
+    public function setInFrame($value) {
+        $this->in_frame = $value;
+    }
+    public function getInFrame() {
+        return $this->in_frame;
+    }
+
+    public function setTemp($value) {
+        $this->temp = $value;
+    }
+    public function getTemp() {
+        return $this->temp;
+    }
+}
+/**
+ * ODTState: class for maintaining the ODT state stack.
+ *
+ * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author  LarsDW223
+ */
+class ODTState
+{
+    protected $stack = array();
+    protected $index = 0;
+
+    /**
+     * Constructor. Set initial state.
+     */
+    public function __construct() {
+        $this->stack [$this->index] = new ODTStateEntry;
+        $this->stack [$this->index]->setElement('root');
+        $this->stack [$this->index]->setClass('root');
+    }
+
+    public function setElement($value) {
+        $this->stack [$this->index]->setElement($value);
+    }
+    public function getElement() {
+        return $this->stack [$this->index]->getElement();
+    }
+
+    public function setClass($value) {
+        $this->stack [$this->index]->setClass($value);
+    }
+    public function getClass() {
+        return $this->stack [$this->index]->getClass();
+    }
+
+    public function setStyleName($value) {
+        $this->stack [$this->index]->setStyleName($value);
+    }
+    public function getStyleName() {
+        return $this->stack [$this->index]->getStyleName();
+    }
+
+    public function setTempStyleName($value) {
+        $this->stack [$this->index]->setTempStyleName($value);
+    }
+    public function getTempStyleName() {
+        return $this->stack [$this->index]->getTempStyleName();
+    }
+
+    public function setInList($value) {
+        $this->stack [$this->index]->setInList($value);
+    }
+    public function getInList() {
+        return $this->stack [$this->index]->getInList();
+    }
+
+    public function setListInterrupted($value) {
+        $this->stack [$this->index]->setListInterrupted($value);
+    }
+    public function getListInterrupted() {
+        return $this->stack [$this->index]->getListInterrupted();
+    }
+
+    public function setListInterruptNow($value) {
+        $this->stack [$this->index]->setListInterruptNow($value);
+    }
+    public function getListInterruptNow() {
+        return $this->stack [$this->index]->getListInterruptNow();
+    }
+
+    public function setInListItem($value) {
+        $this->stack [$this->index]->setInListItem($value);
+    }
+    public function getInListItem() {
+        return $this->stack [$this->index]->getInListItem();
+    }
+
+    public function setInParagraph($value) {
+        $this->stack [$this->index]->setInParagraph($value);
+    }
+    public function getInParagraph() {
+        return $this->stack [$this->index]->getInParagraph();
+    }
+
+    public function setInHeader($value) {
+        $this->stack [$this->index]->setInHeader($value);
+    }
+    public function getInHeader() {
+        return $this->stack [$this->index]->getInHeader();
+    }
+
+    public function setInFrame($value) {
+        $this->stack [$this->index]->setInFrame($value);
+    }
+    public function getInFrame() {
+        return $this->stack [$this->index]->getInFrame();
+    }
+
+    public function setTemp($value) {
+        $this->stack [$this->index]->setTemp($value);
+    }
+    public function getTemp() {
+        return $this->stack [$this->index]->getTemp();
+    }
+
+    public function enter($element, $clazz) {
+        // We enter a new state by making a copy (clone) of the previous state.
+        // The clone() function of ODTStateEntry needs to insure that all params
+        // which SHALL NOT be inherited from the previous state are initialized.
+        $this->index++;
+        $this->stack [$this->index] = clone $this->stack[$this->index-1];
+        $this->stack [$this->index]->setElement($element);
+        $this->stack [$this->index]->setClass($clazz);
+    }
+
+    public function leave() {
+        // We always will keep the initial state.
+        // That means we do nothing if index is 0. This would be a fault anyway.
+        if ($this->index > 0) {
+            unset ($this->stack [$this->index]);
+            $this->index--;
+        }
+    }
+
+    public function reset() {
+        // Throw away any states except the initial state.
+        // Reset index to 0.
+        for ($reset = 1 ; $reset <= $this->index ; $reset++) {
+            unset ($this->stack [$reset]);
+        }
+        $this->index = 0;
+    }
+
+    public function findClosestWithClass($clazz) {
+        for ($search = $this->index ; $search > 0 ; $search--) {
+            if ($this->stack [$search]->getClass() == $clazz) {
+                return $this->stack [$search];
+            }
+        }
+        // Nothing found.
+        return NULL;
+    }
+
+    public function toString () {
+        $indent = '';
+        $string = 'Stackdump:';
+        for ($search = 0 ; $search <= $this->index ; $search++) {
+            $string .= $indent . $this->stack [$search]->getElement().';';
+            $string .= 'inListItem=';
+            if (!$this->stack [$search]->getInList()) {
+                $string .= 'false;'."\n";
+            } else {
+                $string .= 'true;'."\n";
+            }
+            $indent .= '    ';
+        }
+        return $string;
+    }
+}

--- a/ODT/ODTState.php
+++ b/ODT/ODTState.php
@@ -22,7 +22,7 @@ class ODTStateEntry
     protected $table_autocols = false;
     protected $table_maxcols = 0;
     protected $table_curr_column = 0;
-    protected $cols = NULL;
+    protected $table_column_defs = NULL;
     protected $temp_style_name = NULL;
     // Temp pointer for various use! Can point to different things!
     protected $temp = NULL;
@@ -37,7 +37,7 @@ class ODTStateEntry
         $this->table_autocols = false;
         $this->table_maxcols = 0;
         $this->table_curr_column = 0;
-        $this->cols = NULL;
+        $this->table_column_defs = NULL;
 
         $this->list_interrupted = false;
         $this->list_interrupt_now = false;
@@ -153,6 +153,13 @@ class ODTStateEntry
     }
     public function getTableCurrentColumn() {
         return $this->table_curr_column;
+    }
+
+    public function setTableColumnDefs($value) {
+        $this->table_column_defs = $value;
+    }
+    public function getTableColumnDefs() {
+        return $this->table_column_defs;
     }
 }
 /**
@@ -285,6 +292,13 @@ class ODTState
     }
     public function getTableCurrentColumns() {
         return $this->stack [$this->index]->getTableCurrentColumn();
+    }
+
+    public function setTableColumnDefs($value) {
+        $this->stack [$this->index]->setTableColumnDefs($value);
+    }
+    public function getTableColumnDefs() {
+        return $this->stack [$this->index]->getTableColumnDefs();
     }
 
     public function enter($element, $clazz) {

--- a/ODT/ODTState.php
+++ b/ODT/ODTState.php
@@ -8,22 +8,28 @@
  */
 class ODTStateEntry
 {
+    // General state information
     protected $element = NULL;
     protected $clazz = NULL;
     protected $style_name = NULL;
+
+    // List state data
     protected $in_list = false;
     protected $in_list_item = false;
     protected $list_interrupted = false;
-    protected $list_interrupt_now = false;
+
+    // Paragraph or frame entered?
     protected $in_paragraph = false;
     protected $in_frame = false;
+
+    // Table state data
     protected $table_column_styles = array ();
     protected $table_style = NULL;
     protected $table_autocols = false;
     protected $table_maxcols = 0;
     protected $table_curr_column = 0;
     protected $table_column_defs = NULL;
-    protected $temp_style_name = NULL;
+
     // Temp pointer for various use! Can point to different things!
     protected $temp = NULL;
 
@@ -40,7 +46,6 @@ class ODTStateEntry
         $this->table_column_defs = NULL;
 
         $this->list_interrupted = false;
-        $this->list_interrupt_now = false;
     }
 
     public function setElement($value) {
@@ -64,13 +69,6 @@ class ODTStateEntry
         return $this->style_name;
     }
 
-    public function setTempStyleName($value) {
-        $this->temp_style_name = $value;
-    }
-    public function getTempStyleName() {
-        return $this->temp_style_name;
-    }
-
     public function setInList($value) {
         $this->in_list = $value;
     }
@@ -83,13 +81,6 @@ class ODTStateEntry
     }
     public function getListInterrupted() {
         return $this->list_interrupted;
-    }
-
-    public function setListInterruptNow($value) {
-        $this->list_interrupt_now = $value;
-    }
-    public function getListInterruptNow() {
-        return $this->list_interrupt_now;
     }
 
     public function setInListItem($value) {
@@ -165,6 +156,17 @@ class ODTStateEntry
 /**
  * ODTState: class for maintaining the ODT state stack.
  *
+ * In general this is a setter/getter class for ODT states.
+ * The intention is to get rid of some global state variables.
+ * Especially the global error-prone $in_paragraph which easily causes
+ * a document to become invalid if once set wrong. Now each state/element
+ * can set their own instance of $in_paragraph which hopefully makes it use
+ * a bit safer. E.g. for a new table-cell or list-item it can be set to false
+ * because they allow creation of a new paragraph. On leave() we throw the
+ * current state variables away and are safe back from where we came from.
+ * So we also don't need to worry about correct re-initialization of global
+ * variables anymore.
+ * 
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author  LarsDW223
  */
@@ -203,13 +205,6 @@ class ODTState
         return $this->stack [$this->index]->getStyleName();
     }
 
-    public function setTempStyleName($value) {
-        $this->stack [$this->index]->setTempStyleName($value);
-    }
-    public function getTempStyleName() {
-        return $this->stack [$this->index]->getTempStyleName();
-    }
-
     public function setInList($value) {
         $this->stack [$this->index]->setInList($value);
     }
@@ -222,13 +217,6 @@ class ODTState
     }
     public function getListInterrupted() {
         return $this->stack [$this->index]->getListInterrupted();
-    }
-
-    public function setListInterruptNow($value) {
-        $this->stack [$this->index]->setListInterruptNow($value);
-    }
-    public function getListInterruptNow() {
-        return $this->stack [$this->index]->getListInterruptNow();
     }
 
     public function setInListItem($value) {

--- a/ODT/ODTState.php
+++ b/ODT/ODTState.php
@@ -33,6 +33,12 @@ class ODTStateEntry
     // Temp pointer for various use! Can point to different things!
     protected $temp = NULL;
 
+    /**
+     * Clone-Function.
+     * The function should initialize all variables that should not be
+     * inherited from the previous state if a new state is entered.
+     * See function enter().
+     */
     function __clone() {
         $this->element = NULL;
         $this->clazz = NULL;
@@ -48,107 +54,274 @@ class ODTStateEntry
         $this->list_interrupted = false;
     }
 
+    /**
+     * Set the element name to $value.
+     * 
+     * @param string $value Element name e.g. 'text:p'
+     */
     public function setElement($value) {
         $this->element = $value;
     }
+
+    /**
+     * Get the element name.
+     * 
+     * @return string Element name.
+     */
     public function getElement() {
         return $this->element;
     }
 
+    /**
+     * Set the class to $value.
+     * 
+     * @param string $value Class, e.g. 'paragraph'
+     */
     public function setClass($value) {
         $this->clazz = $value;
     }
+
+    /**
+     * Get the class.
+     * 
+     * @return string Class.
+     */
     public function getClass() {
         return $this->clazz;
     }
 
+    /**
+     * Set the style name.
+     * 
+     * @param string $value Style name, e.g. 'body'
+     */
     public function setStyleName($value) {
         $this->style_name = $value;
     }
+
+    /**
+     * Get the style name.
+     * 
+     * @return string Style name.
+     */
     public function getStyleName() {
         return $this->style_name;
     }
 
+    /**
+     * Set flag if we are in a list or not.
+     * 
+     * @param boolean $value
+     */
     public function setInList($value) {
         $this->in_list = $value;
     }
+
+    /**
+     * Get flag if we are in a list or not.
+     * 
+     * @return boolean
+     */
     public function getInList() {
         return $this->in_list;
     }
 
+    /**
+     * Set flag if current list is interrupted (by a table) or not.
+     * 
+     * @param boolean $value
+     */
     public function setListInterrupted($value) {
         $this->list_interrupted = $value;
     }
+
+    /**
+     * Get flag if current list is interrupted (by a table) or not.
+     * 
+     * @return boolean
+     */
     public function getListInterrupted() {
         return $this->list_interrupted;
     }
 
+    /**
+     * Set flag if we are in a list item or not.
+     * 
+     * @param boolean $value
+     */
     public function setInListItem($value) {
         $this->in_list_item = $value;
     }
+
+    /**
+     * Get flag if we are in a list item or not.
+     * 
+     * @return boolean
+     */
     public function getInListItem() {
         return $this->in_list_item;
     }
 
+    /**
+     * Set flag if we are in a paragraph or not.
+     * 
+     * @param boolean $value
+     */
     public function setInParagraph($value) {
         $this->in_paragraph = $value;
     }
+
+    /**
+     * Get flag if we are in a paragraph or not.
+     * 
+     * @return boolean
+     */
     public function getInParagraph() {
         return $this->in_paragraph;
     }
 
+    /**
+     * Set flag if we are in a frame or not.
+     * 
+     * @param boolean $value
+     */
     public function setInFrame($value) {
         $this->in_frame = $value;
     }
+
+    /**
+     * Get flag if we are in a frame or not.
+     * 
+     * @return boolean
+     */
     public function getInFrame() {
         return $this->in_frame;
     }
 
+    /**
+     * Set temporary data for various use.
+     * 
+     * @param mixed $value
+     */
     public function setTemp($value) {
         $this->temp = $value;
     }
+
+    /**
+     * Get temporary data for various use.
+     * 
+     * @return mixed
+     */
     public function getTemp() {
         return $this->temp;
     }
 
+    /**
+     * Set table column styles 
+     * 
+     * @param array $value
+     */
     public function setTableColumnStyles($value) {
         $this->table_column_styles = $value;
     }
+
+    /**
+     * Get table column styles
+     * 
+     * @return array
+     */
     public function getTableColumnStyles() {
         return $this->table_column_styles;
     }
 
+    /**
+     * Set table style name
+     * 
+     * @param string $value
+     */
     public function setTableStyle($value) {
         $this->table_style = $value;
     }
+
+    /**
+     * Get table style name
+     * 
+     * @return string
+     */
     public function getTableStyle() {
         return $this->table_style;
     }
 
+    /**
+     * Set flag if table columns shall be generated automatically.
+     * (automatically detect the number of columns)
+     * 
+     * @param boolean $value
+     */
     public function setTableAutoColumns($value) {
         $this->table_autocols = $value;
     }
+
+    /**
+     * Get flag if table columns shall be generated automatically.
+     * (automatically detect the number of columns)
+     * 
+     * @return boolean
+     */
     public function getTableAutoColumns() {
         return $this->table_autocols;
     }
 
+    /**
+     * Set maximal number of columns.
+     * 
+     * @param integer $value
+     */
     public function setTableMaxColumns($value) {
         $this->table_maxcols = $value;
     }
+
+    /**
+     * Get maximal number of columns.
+     * 
+     * @return integer
+     */
     public function getTableMaxColumns() {
         return $this->table_maxcols;
     }
 
+    /**
+     * Set current column.
+     * 
+     * @param integer $value
+     */
     public function setTableCurrentColumn($value) {
         $this->table_curr_column = $value;
     }
+
+    /**
+     * Get current column.
+     * 
+     * @return integer
+     */
     public function getTableCurrentColumn() {
         return $this->table_curr_column;
     }
 
+    /**
+     * Set column definitions content.
+     * 
+     * @param string $value
+     */
     public function setTableColumnDefs($value) {
         $this->table_column_defs = $value;
     }
+
+    /**
+     * Get column definitions content.
+     * 
+     * @return string
+     */
     public function getTableColumnDefs() {
         return $this->table_column_defs;
     }
@@ -176,7 +349,7 @@ class ODTState
     protected $index = 0;
 
     /**
-     * Constructor. Set initial state.
+     * Constructor. Set initial 'root' state.
      */
     public function __construct() {
         $this->stack [$this->index] = new ODTStateEntry;
@@ -184,111 +357,253 @@ class ODTState
         $this->stack [$this->index]->setClass('root');
     }
 
+    /**
+     * Calls setElement for the current state.
+     * See ODTStateEntry::setElement.
+     */
     public function setElement($value) {
         $this->stack [$this->index]->setElement($value);
     }
+
+    /**
+     * Calls getElement for the current state.
+     * See ODTStateEntry::getElement.
+     */
     public function getElement() {
         return $this->stack [$this->index]->getElement();
     }
 
+    /**
+     * Calls setClass for the current state.
+     * See ODTStateEntry::setClass.
+     */
     public function setClass($value) {
         $this->stack [$this->index]->setClass($value);
     }
+
+    /**
+     * Calls getClass for the current state.
+     * See ODTStateEntry::getClass.
+     */
     public function getClass() {
         return $this->stack [$this->index]->getClass();
     }
 
+    /**
+     * Calls setStyleName for the current state.
+     * See ODTStateEntry::setStyleName.
+     */
     public function setStyleName($value) {
         $this->stack [$this->index]->setStyleName($value);
     }
+
+    /**
+     * Calls getStyleName for the current state.
+     * See ODTStateEntry::getStyleName.
+     */
     public function getStyleName() {
         return $this->stack [$this->index]->getStyleName();
     }
 
+    /**
+     * Calls setInList for the current state.
+     * See ODTStateEntry::setInList.
+     */
     public function setInList($value) {
         $this->stack [$this->index]->setInList($value);
     }
+
+    /**
+     * Calls getInList for the current state.
+     * See ODTStateEntry::getInList.
+     */
     public function getInList() {
         return $this->stack [$this->index]->getInList();
     }
 
+    /**
+     * Calls setListInterrupted for the current state.
+     * See ODTStateEntry::setListInterrupted.
+     */
     public function setListInterrupted($value) {
         $this->stack [$this->index]->setListInterrupted($value);
     }
+
+    /**
+     * Calls getListInterrupted for the current state.
+     * See ODTStateEntry::getListInterrupted.
+     */
     public function getListInterrupted() {
         return $this->stack [$this->index]->getListInterrupted();
     }
 
+    /**
+     * Calls setInListItem for the current state.
+     * See ODTStateEntry::setInListItem.
+     */
     public function setInListItem($value) {
         $this->stack [$this->index]->setInListItem($value);
     }
+
+    /**
+     * Calls getInListItem for the current state.
+     * See ODTStateEntry::getInListItem.
+     */
     public function getInListItem() {
         return $this->stack [$this->index]->getInListItem();
     }
 
+    /**
+     * Calls setInParagraph for the current state.
+     * See ODTStateEntry::setInParagraph.
+     */
     public function setInParagraph($value) {
         $this->stack [$this->index]->setInParagraph($value);
     }
+
+    /**
+     * Calls getInParagraph for the current state.
+     * See ODTStateEntry::getInParagraph.
+     */
     public function getInParagraph() {
         return $this->stack [$this->index]->getInParagraph();
     }
 
+    /**
+     * Calls setInFrame for the current state.
+     * See ODTStateEntry::setInFrame.
+     */
     public function setInFrame($value) {
         $this->stack [$this->index]->setInFrame($value);
     }
+
+    /**
+     * Calls getInFrame for the current state.
+     * See ODTStateEntry::getInFrame.
+     */
     public function getInFrame() {
         return $this->stack [$this->index]->getInFrame();
     }
 
+    /**
+     * Calls setTemp for the current state.
+     * See ODTStateEntry::setTemp.
+     */
     public function setTemp($value) {
         $this->stack [$this->index]->setTemp($value);
     }
+
+    /**
+     * Calls getTemp for the current state.
+     * See ODTStateEntry::getTemp.
+     */
     public function getTemp() {
         return $this->stack [$this->index]->getTemp();
     }
 
+    /**
+     * Calls setTableColumnStyles for the current state.
+     * See ODTStateEntry::setTableColumnStyles.
+     */
     public function setTableColumnStyles($value) {
         $this->stack [$this->index]->setTableColumnStyles($value);
     }
+
+    /**
+     * Calls getTableColumnStyles for the current state.
+     * See ODTStateEntry::getTableColumnStyles.
+     */
     public function getTableColumnStyles() {
         return $this->stack [$this->index]->getTableColumnStyles();
     }
 
+    /**
+     * Calls setTableStyle for the current state.
+     * See ODTStateEntry::setTableStyle.
+     */
     public function setTableStyle($value) {
         $this->stack [$this->index]->setTableStyle($value);
     }
+
+    /**
+     * Calls getTableStyle for the current state.
+     * See ODTStateEntry::getTableStyle.
+     */
     public function getTableStyle() {
         return $this->stack [$this->index]->getTableStyle();
     }
 
+    /**
+     * Calls setTableAutoColumns for the current state.
+     * See ODTStateEntry::setTableAutoColumns.
+     */
     public function setTableAutoColumns($value) {
         $this->stack [$this->index]->setTableAutoColumns($value);
     }
+
+    /**
+     * Calls getTableAutoColumns for the current state.
+     * See ODTStateEntry::getTableAutoColumns.
+     */
     public function getTableAutoColumns() {
         return $this->stack [$this->index]->getTableAutoColumns();
     }
 
+    /**
+     * Calls setTableMaxColumns for the current state.
+     * See ODTStateEntry::setTableMaxColumns.
+     */
     public function setTableMaxColumns($value) {
         $this->stack [$this->index]->setTableMaxColumns($value);
     }
+
+    /**
+     * Calls getTableMaxColumns for the current state.
+     * See ODTStateEntry::getTableMaxColumns.
+     */
     public function getTableMaxColumns() {
         return $this->stack [$this->index]->getTableMaxColumns();
     }
 
+    /**
+     * Calls setTableCurrentColumn for the current state.
+     * See ODTStateEntry::setTableCurrentColumn.
+     */
     public function setTableCurrentColumn($value) {
         $this->stack [$this->index]->setTableCurrentColumn($value);
     }
+
+    /**
+     * Calls getTableCurrentColumn for the current state.
+     * See ODTStateEntry::getTableCurrentColumn.
+     */
     public function getTableCurrentColumns() {
         return $this->stack [$this->index]->getTableCurrentColumn();
     }
 
+    /**
+     * Calls setTableColumnDefs for the current state.
+     * See ODTStateEntry::setTableColumnDefs.
+     */
     public function setTableColumnDefs($value) {
         $this->stack [$this->index]->setTableColumnDefs($value);
     }
+
+    /**
+     * Calls getTableColumnDefs for the current state.
+     * See ODTStateEntry::getTableColumnDefs.
+     */
     public function getTableColumnDefs() {
         return $this->stack [$this->index]->getTableColumnDefs();
     }
 
+    /**
+     * Enter a new state with element name $element and class $clazz.
+     * E.g. 'text:p' and 'paragraph'.
+     * 
+     * @param string $element
+     * @param string $clazz
+     */
     public function enter($element, $clazz) {
         // We enter a new state by making a copy (clone) of the previous state.
         // The clone() function of ODTStateEntry needs to insure that all params
@@ -299,6 +614,9 @@ class ODTState
         $this->stack [$this->index]->setClass($clazz);
     }
 
+    /**
+     * Leave current state. All data of the curent state is thrown away.
+     */
     public function leave() {
         // We always will keep the initial state.
         // That means we do nothing if index is 0. This would be a fault anyway.
@@ -308,6 +626,10 @@ class ODTState
         }
     }
 
+    /**
+     * Reset the state stack/go back to the initial state.
+     * All states except the root state will be discarded.
+     */
     public function reset() {
         // Throw away any states except the initial state.
         // Reset index to 0.
@@ -317,6 +639,12 @@ class ODTState
         $this->index = 0;
     }
 
+    /**
+     * Find the closest state with class $clazz.
+     *
+     * @param string $clazz
+     * @return ODTStateEntry|NULL
+     */
     public function findClosestWithClass($clazz) {
         for ($search = $this->index ; $search > 0 ; $search--) {
             if ($this->stack [$search]->getClass() == $clazz) {
@@ -327,6 +655,11 @@ class ODTState
         return NULL;
     }
 
+    /**
+     * toString() function. Only for creating debug dumps.
+     * 
+     * @return string
+     */
     public function toString () {
         $indent = '';
         $string = 'Stackdump:';

--- a/ODT/ODTState.php
+++ b/ODT/ODTState.php
@@ -19,7 +19,7 @@ class ODTStateEntry
     protected $in_frame = false;
     protected $table_column_styles = array ();
     protected $table_style = NULL;
-    protected $autocols = false;
+    protected $table_autocols = false;
     protected $maxcols = 0;
     protected $column = 0;
     protected $content = NULL;
@@ -135,6 +135,13 @@ class ODTStateEntry
     public function getTableStyle() {
         return $this->table_style;
     }
+
+    public function setTableAutoColumns($value) {
+        $this->table_autocols = $value;
+    }
+    public function getTableAutoColumns() {
+        return $this->table_autocols;
+    }
 }
 /**
  * ODTState: class for maintaining the ODT state stack.
@@ -245,6 +252,13 @@ class ODTState
     }
     public function getTableStyle() {
         return $this->stack [$this->index]->getTableStyle();
+    }
+
+    public function setTableAutoColumns($value) {
+        $this->stack [$this->index]->setTableAutoColumns($value);
+    }
+    public function getTableAutoColumns() {
+        return $this->stack [$this->index]->getTableAutoColumns();
     }
 
     public function enter($element, $clazz) {

--- a/ODT/ODTState.php
+++ b/ODT/ODTState.php
@@ -20,9 +20,8 @@ class ODTStateEntry
     protected $table_column_styles = array ();
     protected $table_style = NULL;
     protected $table_autocols = false;
-    protected $maxcols = 0;
-    protected $column = 0;
-    protected $content = NULL;
+    protected $table_maxcols = 0;
+    protected $table_curr_column = 0;
     protected $cols = NULL;
     protected $temp_style_name = NULL;
     // Temp pointer for various use! Can point to different things!
@@ -35,10 +34,9 @@ class ODTStateEntry
 
         $this->table_column_styles = array ();
         $this->table_style = NULL;
-        $this->autocols = false;
-        $this->maxcols = 0;
-        $this->column = 0;
-        $this->content = NULL;
+        $this->table_autocols = false;
+        $this->table_maxcols = 0;
+        $this->table_curr_column = 0;
         $this->cols = NULL;
 
         $this->list_interrupted = false;
@@ -141,6 +139,20 @@ class ODTStateEntry
     }
     public function getTableAutoColumns() {
         return $this->table_autocols;
+    }
+
+    public function setTableMaxColumns($value) {
+        $this->table_maxcols = $value;
+    }
+    public function getTableMaxColumns() {
+        return $this->table_maxcols;
+    }
+
+    public function setTableCurrentColumn($value) {
+        $this->table_curr_column = $value;
+    }
+    public function getTableCurrentColumn() {
+        return $this->table_curr_column;
     }
 }
 /**
@@ -259,6 +271,20 @@ class ODTState
     }
     public function getTableAutoColumns() {
         return $this->stack [$this->index]->getTableAutoColumns();
+    }
+
+    public function setTableMaxColumns($value) {
+        $this->stack [$this->index]->setTableMaxColumns($value);
+    }
+    public function getTableMaxColumns() {
+        return $this->stack [$this->index]->getTableMaxColumns();
+    }
+
+    public function setTableCurrentColumn($value) {
+        $this->stack [$this->index]->setTableCurrentColumn($value);
+    }
+    public function getTableCurrentColumns() {
+        return $this->stack [$this->index]->getTableCurrentColumn();
     }
 
     public function enter($element, $clazz) {

--- a/ODT/ODTState.php
+++ b/ODT/ODTState.php
@@ -17,7 +17,6 @@ class ODTStateEntry
     protected $list_interrupt_now = false;
     protected $in_paragraph = false;
     protected $in_frame = false;
-    protected $in_header = false;
     protected $table_column_styles = array ();
     protected $table_style = NULL;
     protected $autocols = false;
@@ -109,13 +108,6 @@ class ODTStateEntry
         return $this->in_paragraph;
     }
 
-    public function setInHeader($value) {
-        $this->in_header = $value;
-    }
-    public function getInHeader() {
-        return $this->in_header;
-    }
-
     public function setInFrame($value) {
         $this->in_frame = $value;
     }
@@ -128,6 +120,20 @@ class ODTStateEntry
     }
     public function getTemp() {
         return $this->temp;
+    }
+
+    public function setTableColumnStyles($value) {
+        $this->table_column_styles = $value;
+    }
+    public function getTableColumnStyles() {
+        return $this->table_column_styles;
+    }
+
+    public function setTableStyle($value) {
+        $this->table_style = $value;
+    }
+    public function getTableStyle() {
+        return $this->table_style;
     }
 }
 /**
@@ -213,13 +219,6 @@ class ODTState
         return $this->stack [$this->index]->getInParagraph();
     }
 
-    public function setInHeader($value) {
-        $this->stack [$this->index]->setInHeader($value);
-    }
-    public function getInHeader() {
-        return $this->stack [$this->index]->getInHeader();
-    }
-
     public function setInFrame($value) {
         $this->stack [$this->index]->setInFrame($value);
     }
@@ -232,6 +231,20 @@ class ODTState
     }
     public function getTemp() {
         return $this->stack [$this->index]->getTemp();
+    }
+
+    public function setTableColumnStyles($value) {
+        $this->stack [$this->index]->setTableColumnStyles($value);
+    }
+    public function getTableColumnStyles() {
+        return $this->stack [$this->index]->getTableColumnStyles();
+    }
+
+    public function setTableStyle($value) {
+        $this->stack [$this->index]->setTableStyle($value);
+    }
+    public function getTableStyle() {
+        return $this->stack [$this->index]->getTableStyle();
     }
 
     public function enter($element, $clazz) {

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -52,7 +52,6 @@ class renderer_plugin_odt_page extends Doku_Renderer {
     protected $config = null;
     public $fields = array(); // set by Fields Plugin
     protected $state = null;
-    protected $in_list_item = false;
     protected $in_div_as_frame = 0;
     protected $highlight_style_num = 1;
     protected $temp_table_column_styles = array ();
@@ -1619,16 +1618,18 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         $text = str_replace("\t",'<text:tab/>',$text);
         $text = preg_replace_callback('/(  +)/',array($this,'_preserveSpace'),$text);
 
-        if ($this->in_list_item) { // if we're in a list item, we must close the <text:p> tag
-            $this->doc .= '</text:p>';
-            $this->doc .= '<text:p text:style-name="'.$style.'">';
+        if ($this->state->getInListItem()) {
+            // if we're in a list item, we must close the <text:p> tag
+            $this->p_close();
+            $this->p_open($style);
             $this->doc .= $text;
-            $this->doc .= '</text:p>';
-            $this->doc .= '<text:p>';
+            $this->p_close();
+            // FIXME: query previous style before preformatted text was opened and re-use it here
+            $this->p_open();
         } else {
-            $this->doc .= '<text:p text:style-name="'.$style.'">';
+            $this->p_open($style);
             $this->doc .= $text;
-            $this->doc .= '</text:p>';
+            $this->p_close();
         }
     }
 

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -53,7 +53,6 @@ class renderer_plugin_odt_page extends Doku_Renderer {
     public $fields = array(); // set by Fields Plugin
     protected $state = null;
     protected $highlight_style_num = 1;
-    protected $temp_in_header = false;
     protected $temp_autocols = false;
     protected $temp_maxcols = 0;
     protected $temp_column = 0;
@@ -2897,10 +2896,6 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         
         unset ($this->temp_content);
 
-        // We are starting a new table header declaration.
-        // The flag will be set to false on opening the first table cell of the body.
-        $this->temp_in_header = true;
-
         // Create style.
         $style_obj = $this->factory->createTableTableStyle ($properties, NULL, $this->_getAbsWidthMindMargins (100));
         $this->docHandler->addAutomaticStyle($style_obj);
@@ -3188,11 +3183,6 @@ class renderer_plugin_odt_page extends Doku_Renderer {
      */
     protected function _odtTableCellOpenUsePropertiesInternal ($properties, $inHeader = false, $colspan = 1, $rowspan = 1){
         $disabled = array ();
-
-        if ( $inHeader === false ) {
-            // Table header definition is finished.
-            $this->temp_in_header = false;
-        }
 
         // Create style name. (Re-enable background-color!)
         $style_obj = $this->factory->createTableCellStyle ($properties);

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -53,7 +53,6 @@ class renderer_plugin_odt_page extends Doku_Renderer {
     public $fields = array(); // set by Fields Plugin
     protected $state = null;
     protected $highlight_style_num = 1;
-    protected $temp_maxcols = 0;
     protected $temp_column = 0;
     protected $temp_content = NULL;
     protected $temp_cols = NULL;
@@ -2931,7 +2930,6 @@ class renderer_plugin_odt_page extends Doku_Renderer {
 
         // Reset temporary column counter
         $this->temp_column = 0;
-        $this->temp_maxcols = 0;
     }
 
     protected function _replaceTableWidth () {
@@ -2954,7 +2952,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         // Abort if a column has a percentage width or no width.
         $sum = 0;
         $table_column_styles = $table->getTableColumnStyles();
-        for ($index = 0 ; $index < $this->temp_maxcols ; $index++ ) {
+        for ($index = 0 ; $index < $table->getTableMaxColumns() ; $index++ ) {
             $style_name = $table_column_styles [$index];
             $style_obj = $this->docHandler->getStyle($style_name);
             if ($style_obj != NULL && $style_obj->getProperty('column-width') != NULL) {
@@ -2990,7 +2988,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
                     str_replace ('<ColumnsPlaceholder>', $this->temp_cols, $this->doc);
 
                 $this->doc =
-                    str_replace ('<MaxColsPlaceholder>', $this->temp_maxcols, $this->doc);
+                    str_replace ('<MaxColsPlaceholder>', $table->getTableMaxColumns(), $this->doc);
 
                 unset ($this->temp_content);
                 unset ($this->temp_cols);
@@ -3039,6 +3037,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         if ($table != NULL) {
             $table_column_styles = $table->getTableColumnStyles();
             $auto_columns = $table->getTableAutoColumns();
+            $max_columns = $table->getTableMaxColumns();
         }
         $style_name = $table_column_styles [$this->temp_column];
         $properties ['style-name'] = $style_name;
@@ -3052,10 +3051,10 @@ class renderer_plugin_odt_page extends Doku_Renderer {
 
         // Eventually add a new temp column if in auto mode
         if ( $auto_columns === true ) {
-            if ( $this->temp_column > $this->temp_maxcols ) {
+            if ( $this->temp_column > $max_columns ) {
                 // Add temp column.
                 $this->temp_cols .= '<table:table-column table:style-name="'.$style_name.'"/>';
-                $this->temp_maxcols++;
+                $table->setTableMaxColumns($max_columns + 1);
             }
         }
     }

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -81,8 +81,6 @@ class renderer_plugin_odt_page extends Doku_Renderer {
     protected $changePageFormat = NULL;
     /** @var string */
     protected $css;
-    /** @var  string buffer for extracted template */
-    protected $temp_dir;
     /** @var  int counter for styles */
     protected $style_count;
 


### PR DESCRIPTION
Re-factored management of state variables.

Global state variables have been put on a state stack. So each element can keep it's own set of states. Some states e.g. inParagraph are inherited from the previous state/parent element, others not.

The main goal is to prevent invalid documents caused by wrong usage of global state variables especially inParagraph. This easily caused trouble before because one global variable is not sufficient for elements which allow/enable nested paragraphs.