### PR TITLE
Changed style to keep pagetool icon on left side for rtl languages

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,4 +20,10 @@
 #dokuwiki__pagetools ul li a.export_odt:focus {
     background-position: right -45px;
 }
+/*Keep pagetool icon on left side for rtl languages*/
+[dir=rtl] #dokuwiki__pagetools ul li a.export_odt:hover,
+#dokuwiki__pagetools ul li a.export_odt:active,
+#dokuwiki__pagetools ul li a.export_odt:focus {
+    background-position: left -45px;
+}
 


### PR DESCRIPTION
For languages that read from right to left, the page tool icon covers text on the right side, moving it to the left side takes care of that problem.