### PR TITLE
Check acl, continues export with book_skipforbiddenpages=1 is set

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -22,6 +22,7 @@ $lang['update_chapter_msg'] = 'Please remember to update the Chapter Index after
 $lang['needtitle']         = "Please provide a title.";
 $lang['needns']            = "Please provide an existing namespace.";
 $lang['empty']             = "You don't have pages selected yet.";
+$lang['forbidden']         = "You have no access to these pages: %s. Use option 'Skip Forbidden Pages' or add '&book_skipforbiddenpages=1' to your export-url";
 
 // Error message for failed conversion.
 // The following replacments are supported:

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -22,7 +22,7 @@ $lang['update_chapter_msg'] = 'Please remember to update the Chapter Index after
 $lang['needtitle']         = "Please provide a title.";
 $lang['needns']            = "Please provide an existing namespace.";
 $lang['empty']             = "You don't have pages selected yet.";
-$lang['forbidden']         = "You have no access to these pages: %s. Use option 'Skip Forbidden Pages' or add '&book_skipforbiddenpages=1' to your export-url";
+$lang['forbidden']         = "You have no access to these pages: %s.<br/><br/>Use option 'Skip Forbidden Pages' to create your book with the available pages.";
 
 // Error message for failed conversion.
 // The following replacments are supported:


### PR DESCRIPTION
Default it shows a message which warns that selection contains acl protected pages.
To continue the url parameter book_skipforbiddenpages=1 is required.