### PR TITLE
Fix for wrong image size

### DIFF
--- a/renderer/page.php
+++ b/renderer/page.php
@@ -3008,6 +3008,8 @@ class renderer_plugin_odt_page extends Doku_Renderer {
             if ($height) $height = (($height/96.0)*2.54);
         }
 
+        $width = str_replace(',', '.', $width);
+        $height = str_replace(',', '.', $height);
         if ($width && $height) {
             // Don't be wider than the page
             if ($width >= 17){ // FIXME : this assumes A4 page format with 2cm margins

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -2896,11 +2896,9 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         }
         // make sure width and height are available
         if (!$width || !$height) {
-            list($width, $height) = $this->_odtGetImageSizeString($src, $width, $height);
+            list($width, $height) = $this->_odtGetImageSizeString($src, $width, $height, true);
         } else {
-            // Adjust values for ODT
-            $width = $this->adjustXLengthValueForODT ($width);
-            $height = $this->adjustYLengthValueForODT ($height);
+            list($width, $height) = $this->_odtGetImageSizeString($src, $width, $height, false);
         }
 
         if($align){
@@ -2999,9 +2997,9 @@ class renderer_plugin_odt_page extends Doku_Renderer {
      * @param  $height
      * @return array
      */
-    function _odtGetImageSizeString($src, $width = NULL, $height = NULL){
+    function _odtGetImageSizeString($src, $width = NULL, $height = NULL, $preferImage=true){
         list($width_file, $height_file) = $this->_odtGetImageSize($src);
-        if ($width_file != 0) {
+        if ($width_file != 0 && $preferImage) {
             $width  = $width_file;
             $height = $height_file;
         } else {


### PR DESCRIPTION
This pull-request fixes to issues:
- images with the original size specified via ? did not have the same size as if the image would have been included without the ?
- image width or height could include a comma which is illegal (only dot allowed). This depends on the server's PHP locale settings