### PR TITLE
The translation tool doesn't like spaces in the lang array syntax

### DIFF
--- a/lang/de-informal/settings.php
+++ b/lang/de-informal/settings.php
@@ -2,9 +2,9 @@
 
 /**
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * 
+ *
  * @author Florian Lamml <info@florian-lamml.de>
- * 
+ *
  * @package DokuWiki\lang\de-informal\settings
  */
 $lang['tpl_dir']               = 'Unterverzeichnis für Vorlagen im Media Manager';
@@ -15,10 +15,10 @@ $lang['css_usage']             = 'Importiertes CSS auf ODT-Styles anwenden?';
 $lang['media_sel']             = 'Welcher @media Selektor soll verwendet werden um CSS-Eigenschaften abzufragen?';
 $lang['css_font_size']         = 'CSS Basis-Schriftgröße (definiert 1em)';
 $lang['css_template']          = 'Welches Template soll zur Formatierung der ODT-Dateien verwendet werden?';
-$lang ['apply_fs_to_non_css']  = 'CSS Basis-Schriftgröße auf ODT-Template und Plugin Default-Styles anwenden?';
+$lang['apply_fs_to_non_css']   = 'CSS Basis-Schriftgröße auf ODT-Template und Plugin Default-Styles anwenden?';
 
-$lang ['twips_per_pixel_x']    = 'Twips pro Pixel (X-Achse)';
-$lang ['twips_per_pixel_y']    = 'Twips pro Pixel (Y-Achse)';
+$lang['twips_per_pixel_x']     = 'Twips pro Pixel (X-Achse)';
+$lang['twips_per_pixel_y']     = 'Twips pro Pixel (Y-Achse)';
 
 $lang['format']                = 'Seitenformat';
 $lang['orientation']           = 'Seiten-Ausrichtung';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -2,10 +2,10 @@
 
 /**
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * 
+ *
  * @author Matthias Schulte <dokuwiki@lupo49.de>
  * @author Florian Lamml <info@florian-lamml.de>
- * 
+ *
  * @package DokuWiki\lang\de\settings
  */
 $lang['tpl_dir']               = 'Unterverzeichnis für Vorlagen im Medienmanager';
@@ -16,10 +16,10 @@ $lang['css_usage']             = 'Importiertes CSS auf ODT-Styles anwenden?';
 $lang['media_sel']             = 'Welcher @media Selektor soll verwendet werden um CSS-Eigenschaften abzufragen?';
 $lang['css_font_size']         = 'CSS Basis-Schriftgröße (definiert 1em)';
 $lang['css_template']          = 'Welches Template soll zur Formatierung der ODT-Dateien verwendet werden?';
-$lang ['apply_fs_to_non_css']  = 'CSS Basis-Schriftgröße auf ODT-Template und Plugin Default-Styles anwenden?';
+$lang['apply_fs_to_non_css']   = 'CSS Basis-Schriftgröße auf ODT-Template und Plugin Default-Styles anwenden?';
 
-$lang ['twips_per_pixel_x']    = 'Twips pro Pixel (X-Achse)';
-$lang ['twips_per_pixel_y']    = 'Twips pro Pixel (Y-Achse)';
+$lang['twips_per_pixel_x']     = 'Twips pro Pixel (X-Achse)';
+$lang['twips_per_pixel_y']     = 'Twips pro Pixel (Y-Achse)';
 
 $lang['format']                = 'Seitenformat';
 $lang['orientation']           = 'Seiten-Ausrichtung';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -20,10 +20,10 @@ $lang['css_usage'] = 'Apply imported CSS to ODT styles?';
 $lang['media_sel'] = 'Which @media selector shall be used to query CSS properties?';
 $lang['css_font_size'] = 'CSS base font size (defining 1em)';
 $lang['css_template'] = 'Which template should be used for formatting the ODT files?';
-$lang ['apply_fs_to_non_css'] = 'Apply CSS font size to ODT template and plugin default styles?';
+$lang['apply_fs_to_non_css'] = 'Apply CSS font size to ODT template and plugin default styles?';
 
-$lang ['twips_per_pixel_x'] = 'Twips per pixel (X axis)';
-$lang ['twips_per_pixel_y'] = 'Twips per pixel (Y axis)';
+$lang['twips_per_pixel_x'] = 'Twips per pixel (X axis)';
+$lang['twips_per_pixel_y'] = 'Twips per pixel (Y axis)';
 
 $lang['format']                = 'Page format';
 $lang['orientation']           = 'Page orientation';


### PR DESCRIPTION
Fixes hopefully #172, and fixes https://github.com/LarsGit223/dokuwiki-plugin-odt/commit/ba98fae1158872a0421bc216ce69780b39102986#commitcomment-19310175