### PR TITLE
declare methods as static

### DIFF
--- a/ODT/ODTFrame.php
+++ b/ODT/ODTFrame.php
@@ -117,7 +117,7 @@ class ODTFrame
      * 
      * @param     ODTInternalParams $params     Commom params.
      */
-    function closeTextBox (ODTInternalParams $params) {
+    public static function closeTextBox (ODTInternalParams $params) {
         // Close paragraph (if open)
         $params->document->paragraphClose();
         // Close text box
@@ -361,7 +361,7 @@ class ODTFrame
      * 
      * @param     ODTInternalParams $params     Commom params.
      */
-    function closeFrame (ODTInternalParams $params) {
+    public static function closeFrame (ODTInternalParams $params) {
         $frame = $params->document->state->getCurrentFrame();
         if ($frame == NULL) {
             // ??? Error. Not table found.

--- a/ODT/ODTParagraph.php
+++ b/ODT/ODTParagraph.php
@@ -26,7 +26,7 @@ class ODTParagraph
      * @param     string            $element    The element name, e.g. "div"
      * @param     string            $attributes The attributes belonging o the element, e.g. 'class="example"'
      */
-    static public function paragraphOpen(ODTInternalParams $params, $styleName=NULL, $element=NULL, $attributes=NULL){
+    public static function paragraphOpen(ODTInternalParams $params, $styleName=NULL, $element=NULL, $attributes=NULL){
         if ($element == NULL) {
             $element = 'p';
         }
@@ -129,7 +129,7 @@ class ODTParagraph
      * 
      * @param     ODTInternalParams $params     Commom params.
      */
-    static public function paragraphClose(ODTInternalParams $params){
+    public static function paragraphClose(ODTInternalParams $params){
         $paragraph = $params->document->state->getCurrentParagraph();
         if ($paragraph != NULL) {
             ODTUtility::closeHTMLElement ($params, $paragraph->getHTMLElement());
@@ -155,7 +155,7 @@ class ODTParagraph
      * @param     string            $element    The element name, e.g. "div"
      * @param     string            $attributes The attributes belonging o the element, e.g. 'class="example"'
      */
-    function paragraphOpenUseCSS(ODTInternalParams $params, $element=NULL, $attributes=NULL){
+    public static function paragraphOpenUseCSS(ODTInternalParams $params, $element=NULL, $attributes=NULL){
         $inParagraph = $params->document->state->getInParagraph();
         if ($inParagraph) {
             return;

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -347,7 +347,7 @@ class ODTUtility
 
         // First do simple adjustments per property
         foreach ($properties as $property => $value) {
-            $properties [$property] = ODTUtility::adjustValueForODT ($property, $value, $units);
+            $properties [$property] = self::adjustValueForODT ($property, $value, $units);
         }
 
         // Adjust relative margins if $maxWidth is given.
@@ -511,7 +511,7 @@ class ODTUtility
         $params->import->getPropertiesForElement($dest, $toMatch, $params->units);
 
         // Adjust values for ODT
-        ODTUtility::adjustValuesForODT($dest, $params->units, $maxWidth);
+        self::adjustValuesForODT($dest, $params->units, $maxWidth);
     }
 
     /**
@@ -548,7 +548,7 @@ class ODTUtility
         $params->import->getPropertiesForElement($dest, $toMatch, $params->units, $inherit);
 
         // Adjust values for ODT
-        ODTUtility::adjustValuesForODT($dest, $params->units, $maxWidth);
+        self::adjustValuesForODT($dest, $params->units, $maxWidth);
 
         // Remove element from stack
         $params->htmlStack->removeCurrent();
@@ -636,7 +636,7 @@ class ODTUtility
      * @param array $matches
      * @return string
      */
-    function _preserveSpace($matches){
+    protected static function _preserveSpace($matches){
         $spaces = $matches[1];
         $len    = strlen($spaces);
         return '<text:s text:c="'.$len.'"/>';
@@ -647,7 +647,7 @@ class ODTUtility
         if ($styleName == NULL || !$params->document->styleExists($styleName)) {
             // Get properties
             $properties = array();        
-            ODTUtility::getHTMLElementProperties ($params, $properties, $element, $attributes);
+            self::getHTMLElementProperties ($params, $properties, $element, $attributes);
 
             if ($styleName == NULL) {
                 $properties ['style-name'] = ODTStyle::getNewStylename ('span');
@@ -730,7 +730,7 @@ class ODTUtility
         $max = strlen ($HTMLCode);
         $pos = 0;
         while ($pos < $max) {
-            $found = ODTUtility::getNextTag($HTMLCode, $pos);
+            $found = self::getNextTag($HTMLCode, $pos);
             if ($found !== false) {
                 $entry = array();
                 $entry ['content'] = substr($HTMLCode, $pos, $found [0]-$pos);
@@ -909,7 +909,7 @@ class ODTUtility
 
         // Preserve space?
         if ($options ['space'] === 'preserve') {
-            $content = preg_replace_callback('/(  +)/',array('ODTUtility','_preserveSpace'),$content);
+            $content = preg_replace_callback('/(  +)/',array(self,'_preserveSpace'),$content);
         }
 
         $params->content .= $content;

--- a/ODT/css/cssimportnew.php
+++ b/ODT/css/cssimportnew.php
@@ -68,7 +68,7 @@ class css_attribute_selector {
     public function matches (array $attributes=NULL) {
         if ($this->operator == NULL) {
             // Attribute should be present
-            return array_key_exists($this->attribute, $attributes);
+            return isset($attributes) && array_key_exists($this->attribute, $attributes);
         } else {
             switch ($this->operator) {
                 case '=':


### PR DESCRIPTION
prevent PHP warnings: `PHP Deprecated:  Non-static methods should not be called statically` in PHP 7.1
Following functions should be declared explicitly as **static**:
* ODTFrame::closeTextBox()
* ODTFrame::closeFrame()
* ODTParagraph::paragraphOpenUseCSS()
* ODTUtility::_preserveSpace()
