### PR TITLE
Replace metadata when using a template

### DIFF
--- a/ODT/ODTExport.php
+++ b/ODT/ODTExport.php
@@ -153,6 +153,9 @@ class ODTExport
             throw new Exception(' Error extracting the zip archive:'.$template.' to '.$tempDir);
         }
 
+        // Replace metadata
+        io_saveFile($tempDir.'/meta.xml', $meta);
+
         // Evtl. copy page format of first page to different style
         $first_master = $params->styleset->getStyleAtIndex ('office:master-styles', 0);
         if ($first_master != NULL &&


### PR DESCRIPTION
The original template metadata (author, title etc.) will in most cases
be meaningless to the generated document, plus it contains data (like
word count) that will be invalid. Therefore, replace it completely with
the metadata that would be included if there were no template.