### PR TITLE
Bring single page title in line with other DW practice

### DIFF
--- a/renderer/page.php
+++ b/renderer/page.php
@@ -150,6 +150,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
     function document_setup()
     {
         global $ID;
+        global $conf;
 
         // First, get export mode.
         $warning = '';
@@ -235,7 +236,17 @@ class renderer_plugin_odt_page extends Doku_Renderer {
 
         // Set title in meta info.
         // FIXME article title != book title  SOLUTION: overwrite at the end for book
-        $this->document->setTitle($ID);
+        $title = p_get_first_heading($ID);
+        if (empty($title)) {
+            $title = noNS($ID);
+            if ($title == $conf['start'] || $title == false) {
+                $title = noNS(getNS($ID));
+                if ($title == false) {
+                    $title = $ID;
+                }
+            }
+        }
+        $this->document->setTitle($title);
 
         // Enable/disable links according to configuration
         $disabled = $this->config->getParam ('disable_links');


### PR DESCRIPTION
When exporting a single page, the ODT plugin uses the page ID as the title of the generated ODT document. This is contrary to general Dokuwiki practice, which uses the first page heading, or (in the absence of that) the page name without the namespace as the page title.
This patch recitifies that by generating the title in a way more consistent with for example many navigation plugins.