### PR TITLE
Fix Bookcreator ODT export

### DIFF
--- a/action/export.php
+++ b/action/export.php
@@ -302,8 +302,7 @@ class action_plugin_odt_export extends DokuWiki_Action_Plugin {
 //                exit();
 //            }
 
-            $json = new JSON(JSON_LOOSE_TYPE);
-            $list = $json->decode($INPUT->post->str('selection', '', true));
+            $list = json_decode($INPUT->post->str('selection', '', true));
             if(!is_array($list) || empty($list)) {
                 http_status(400);
                 print $this->getLang('empty');


### PR DESCRIPTION
Fixes the following error on DokuWiki Logs:

```
2025-09-10 22:56:41
Error: Class "JSON" not found
/home/admin/domains/wiki.example.com/public_html/lib/plugins/odt/action/export.php(305)
#0 /home/admin/domains/wiki.example.com/public_html/lib/plugins/odt/action/export.php(187): action_plugin_odt_export->collectExportPages()
#1 /home/admin/domains/wiki.example.com/public_html/inc/Extension/EventHandler.php(80): action_plugin_odt_export->convert()
#2 /home/admin/domains/wiki.example.com/public_html/inc/Extension/Event.php(75): dokuwiki\Extension\EventHandler->process_event()
#3 /home/admin/domains/wiki.example.com/public_html/inc/ActionRouter.php(83): dokuwiki\Extension\Event->advise_before()
#4 /home/admin/domains/wiki.example.com/public_html/inc/ActionRouter.php(49): dokuwiki\ActionRouter->setupAction()
#5 /home/admin/domains/wiki.example.com/public_html/inc/ActionRouter.php(62): dokuwiki\ActionRouter->__construct()
#6 /home/admin/domains/wiki.example.com/public_html/inc/actions.php(19): dokuwiki\ActionRouter::getInstance()
#7 /home/admin/domains/wiki.example.com/public_html/doku.php(131): act_dispatch()
#8 {main}
```